### PR TITLE
Fix Datadog APM metrics by always exporting spans

### DIFF
--- a/opentelemetry-datadog/src/exporter/mod.rs
+++ b/opentelemetry-datadog/src/exporter/mod.rs
@@ -16,7 +16,7 @@ use opentelemetry::sdk::export::trace;
 use opentelemetry::sdk::export::trace::SpanData;
 use opentelemetry::sdk::resource::ResourceDetector;
 use opentelemetry::sdk::resource::SdkProvidedResourceDetector;
-use opentelemetry::sdk::trace::{Config, TraceRuntime};
+use opentelemetry::sdk::trace::{Config, Sampler, TraceRuntime};
 use opentelemetry::sdk::Resource;
 use opentelemetry::trace::TraceError;
 use opentelemetry::{global, sdk, trace::TracerProvider, KeyValue};
@@ -198,38 +198,32 @@ impl DatadogPipelineBuilder {
     }
 
     fn build_config_and_service_name(&mut self) -> (Config, String) {
-        let service_name = self.unified_tags.service();
-        if let Some(service_name) = service_name {
-            let config = if let Some(mut cfg) = self.trace_config.take() {
-                cfg.resource = Cow::Owned(Resource::new(
-                    cfg.resource
-                        .iter()
-                        .filter(|(k, _v)| **k != semcov::resource::SERVICE_NAME)
-                        .map(|(k, v)| KeyValue::new(k.clone(), v.clone())),
-                ));
-                cfg
-            } else {
-                Config {
-                    resource: Cow::Owned(Resource::empty()),
-                    ..Default::default()
-                }
-            };
-            (config, service_name)
-        } else {
-            let service_name = SdkProvidedResourceDetector
+        let service_name = self.unified_tags.service().unwrap_or_else(|| {
+            SdkProvidedResourceDetector
                 .detect(Duration::from_secs(0))
                 .get(semcov::resource::SERVICE_NAME)
                 .unwrap()
-                .to_string();
-            (
-                Config {
-                    // use a empty resource to prevent TracerProvider to assign a service name.
-                    resource: Cow::Owned(Resource::empty()),
-                    ..Default::default()
-                },
-                service_name,
-            )
-        }
+                .to_string()
+        });
+
+        let mut config = self.trace_config.take().unwrap_or_default();
+
+        // Remove the service name from the resource to prevent TracerProvider from assigning a
+        // service name.
+        config.resource = Cow::Owned(Resource::new(
+            config
+                .resource
+                .iter()
+                .filter(|(k, _v)| **k != semcov::resource::SERVICE_NAME)
+                .map(|(k, v)| KeyValue::new(k.clone(), v.clone())),
+        ));
+
+        // We always need to send spans to the datadog agent, even if they aren't
+        // sampled, so that the agent correctly reports APM metrics. The agent is then
+        // responsible for dropping the span.
+        config.sampler = Box::new(Sampler::AlwaysRecord(config.sampler));
+
+        (config, service_name)
     }
 
     // parse the endpoint and append the path based on versions.

--- a/opentelemetry-datadog/src/exporter/mod.rs
+++ b/opentelemetry-datadog/src/exporter/mod.rs
@@ -297,8 +297,11 @@ impl DatadogPipelineBuilder {
     ) -> Result<sdk::trace::Tracer, TraceError> {
         let (config, service_name) = self.build_config_and_service_name();
         let exporter = self.build_exporter_with_service_name(service_name)?;
+        let batch = sdk::trace::BatchSpanProcessor::builder(exporter, runtime)
+            .with_drop_if_not_sampled(false)
+            .build();
         let mut provider_builder =
-            sdk::trace::TracerProvider::builder().with_batch_exporter(exporter, runtime);
+            sdk::trace::TracerProvider::builder().with_span_processor(batch);
         provider_builder = provider_builder.with_config(config);
         let provider = provider_builder.build();
         let tracer = provider.versioned_tracer(

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -105,7 +105,7 @@ pub struct SimpleSpanProcessor {
 }
 
 impl SimpleSpanProcessor {
-    pub(crate) fn new(mut exporter: Box<dyn SpanExporter>) -> Self {
+    pub fn new(mut exporter: Box<dyn SpanExporter>) -> Self {
         let (span_tx, span_rx) = crossbeam_channel::unbounded();
         let (shutdown_tx, shutdown_rx) = crossbeam_channel::bounded(0);
 
@@ -132,6 +132,11 @@ impl SimpleSpanProcessor {
             sender: span_tx,
             shutdown: shutdown_rx,
         }
+    }
+
+    pub fn with_drop_if_not_sampled(mut self, should_drop: bool) -> Self {
+        self.drop_if_not_sampled = should_drop;
+        self
     }
 }
 


### PR DESCRIPTION
Datadog APM expects all spans to be exported to the agent regardless of whether they are sampled or not, so that they can be accounted for in derived metrics before being dropped by the agent. This PR changes the default behavior of the Datadog exporter so that spans are always recorded/exported by default.