### PR TITLE
Datadog: fix trace ID generation when no remote context

### DIFF
--- a/opentelemetry-datadog/src/lib.rs
+++ b/opentelemetry-datadog/src/lib.rs
@@ -298,11 +298,9 @@ mod propagator {
         }
 
         fn extract_with_context(&self, cx: &Context, extractor: &dyn Extractor) -> Context {
-            let extracted = self
-                .extract_span_context(extractor)
-                .unwrap_or_else(|_| SpanContext::empty_context());
-
-            cx.with_remote_span_context(extracted)
+            self.extract_span_context(extractor)
+                .map(|span_cx| cx.with_remote_span_context(span_cx))
+                .unwrap_or_else(|_| cx.clone())
         }
 
         fn fields(&self) -> FieldIter<'_> {


### PR DESCRIPTION
Trace IDs are only generated when building spans where there is no parent context already present. This change ensures trace IDs are generated when no remote context is available by only extending context remote span context is successfully extracted.